### PR TITLE
[QA] Ignoring suffixed env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ celerybeat-schedule.*
 
 # Environments 
 .env 
+.env.*
 .venv 
 env/ 
 venv/ 


### PR DESCRIPTION
In order to prevent that files like: `.env.local` or `.env.test` been added to git tree